### PR TITLE
Empty collection does not throw an error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,9 +1962,9 @@
       "dev": true
     },
     "flatbush": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-2.0.2.tgz",
-      "integrity": "sha512-o30jvowagNlaIs9QfPfAzeiLkIjBinbW1uEeQ2RwUN5NEon1bN8cRGf0SaeZPClAu583/yTN6EX4dCpmBE8jjw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-2.0.4.tgz",
+      "integrity": "sha512-4ve0+LFFrQ0Bs+wnU2W4pKU/kFG7Tfz1VeulbbjeaQwvJUzzqqbSiQPYLtQjghqn+IMxQN6U9LWlAP4hVCO1Sg=="
     },
     "from2": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "ISC",
   "dependencies": {
     "cheap-ruler": "^2.4.0",
-    "flatbush": "^2.0.2",
+    "flatbush": "^2.0.4",
     "turf-linestring": "^1.0.0",
     "xtend": "^4.0.0"
   },

--- a/probematch.js
+++ b/probematch.js
@@ -43,6 +43,9 @@ function indexNetwork(options, network) {
   var segments = [];
   var load = [];
 
+  // flatbush will throw an error for an empty index.
+  if (network.length === 0) return {segments: [], bush: null};
+
   for (var i = 0; i < network.length; i++) {
     var coords = network[i].geometry.coordinates;
     var ruler = cheapRuler(coords[0][1], 'kilometers');
@@ -116,7 +119,12 @@ function match(options, network, index, probe, bearing, ruler) {
     (bearing === null || typeof bearing === 'undefined')) return [];
   if (bearing && bearing < 0) bearing = bearing + 360;
 
-  var hits = index.bush.search(probeCoords[0], probeCoords[1], probeCoords[0], probeCoords[1]);
+  var hits;
+  if (!index.bush) {
+    hits = [];
+  } else {
+    hits = index.bush.search(probeCoords[0], probeCoords[1], probeCoords[0], probeCoords[1]);
+  }
   var matches = filterMatchHits(options, network, index.segments, hits, probeCoords, bearing, ruler);
 
   matches.sort(sortByDistance);

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,16 @@ test('probematch -- returns scored roads', function (t) {
   t.end();
 });
 
+test('probematch -- empty roads', function (t) {
+  var match = probematch({type: 'FeatureCollection', features: []}, {compareBearing: false});
+  var probe = point([-77.03038215637207, 38.909639917926036]);
+
+  var matched = match(probe);
+
+  t.equal(matched.length, 0);
+  t.end();
+});
+
 test('probematch -- including bearing limits matches', function (t) {
   var match = probematch(load());
   var probe = point([-77.03038215637207, 38.909639917926036]);


### PR DESCRIPTION
Compared to r-bush, flatbush throws an error when indexing 0 features.