### PR TITLE
Update to flatbush@3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "cheap-ruler": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-2.4.1.tgz",
@@ -1962,9 +1972,9 @@
       "dev": true
     },
     "flatbush": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-2.0.4.tgz",
-      "integrity": "sha512-4ve0+LFFrQ0Bs+wnU2W4pKU/kFG7Tfz1VeulbbjeaQwvJUzzqqbSiQPYLtQjghqn+IMxQN6U9LWlAP4hVCO1Sg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-3.0.0.tgz",
+      "integrity": "sha512-RfIR6cqvvU9Oq5LpM2E9K+HByDCBaUUMawT0N+PkD9USmR7ig/ewDPS4/X+AqQqnCkeKIfCxeLz5Ut/YR9yMHQ=="
     },
     "from2": {
       "version": "2.3.0",
@@ -2013,16 +2023,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "ISC",
   "dependencies": {
     "cheap-ruler": "^2.4.0",
-    "flatbush": "^2.0.4",
+    "flatbush": "^3.0.0",
     "turf-linestring": "^1.0.0",
     "xtend": "^4.0.0"
   },

--- a/probematch.js
+++ b/probematch.js
@@ -66,11 +66,11 @@ function indexNetwork(options, network) {
 
 /**
  * Takes the coordinates of a road segment, configuring it for
- * rbush indexing and lookups.
+ * flatbush indexing and lookups.
  *
  * @param      {object}  options           probematch configuration object
  * @param      {array}   segments          Array that will hold segment linestrings
- * @param      {array}   load              Array that will hold bboxes to index in rbush
+ * @param      {array}   load              Array that will hold bboxes to index in flatbush
  * @param      {int}     roadId            Numeric index of which road in the network this segment belongs to
  * @param      {int}     segmentId         Numeric index of which segment in the road `a` and `b` represent
  * @param      {array}   a                 First coordinate of the current segment
@@ -105,7 +105,7 @@ function prepSegment(options, segments, load, roadId, segmentId, a, b, ruler) {
  * @param  {object}                     options   probematch configuration object
  * @param  {array}                      network   Array of the road network's linestring features
  * @param  {array}                      segments  Array holding linestrings of each segment in the road network
- * @param  {object}                     tree      Rbush tree of segment bounding boxes
+ * @param  {object}                     tree      flatbush tree of segment bounding boxes
  * @param  {Point|Feature<Point>|array} probe     Probe to match to the road network
  * @param  {number}                     bearing   Bearing of the probe
  * @param  {object}                     ruler     A cheap ruler instance
@@ -171,7 +171,7 @@ function filterMatchHits(options, network, segments, hits, probeCoords, bearing,
  * @param      {object}                         options   probematch configuration object
  * @param      {array}                          network   Array of the road network's linestring features
  * @param      {array}                          segments  Array holding linestrings of each segment in the road network
- * @param      {object}                         tree      Rbush tree of segment bounding boxes
+ * @param      {object}                         tree      flatbush tree of segment bounding boxes
  * @param      {LineString|Feature<LineString>} trace     Trace to match to the network
  * @return     {array}   matches for each point of `trace`
  */


### PR DESCRIPTION
- Fix some of the JSDoc strings that referenced rbush instead of flatbush
- Update flatbush to version 3.

cc @mourner 